### PR TITLE
feat: default pricing fallback and runtime reload

### DIFF
--- a/integrations/oi-filter/pricing.json
+++ b/integrations/oi-filter/pricing.json
@@ -564,6 +564,10 @@
         "deepseek-reasoner":{
             "promptPrice": 0.00055,
             "completionPrice": 0.00219
+        },
+        "default": {
+            "promptPrice": 0.0001,
+            "completionPrice": 0.0001
         }
     }
 }

--- a/integrations/oi-filter/pricing.json
+++ b/integrations/oi-filter/pricing.json
@@ -141,6 +141,22 @@
             "promptPrice": 0.0001,
             "completionPrice": 0.0001
         },
+        "llama3.2": {
+            "promptPrice": 0.0003,
+            "completionPrice": 0.0003
+        },
+        "llama3.2:latest": {
+            "promptPrice": 0.0003,
+            "completionPrice": 0.0003
+        },
+        "llama3.2:3b": {
+            "promptPrice": 0.0003,
+            "completionPrice": 0.0003
+        },
+        "llama3.2:latest": {
+            "promptPrice": 0.0003,
+            "completionPrice": 0.0003
+        },
         "gpt-4o": {
             "promptPrice": 0.0005,
             "completionPrice": 0.0015

--- a/integrations/oi-filter/suse_ai_filter.py
+++ b/integrations/oi-filter/suse_ai_filter.py
@@ -79,18 +79,24 @@ class Pipeline:
         self.setup()
 
     def get_chat_model_cost(self, model, prompt, completion):
+        chat_prices = (self.cost_estimation or {}).get("chat", {})
+        pricing = chat_prices.get(model)
+        if pricing is None:
+            pricing = chat_prices.get("default")
+            if pricing is None:
+                raise UndefinedPriceError
+            self.log(
+                f"Model '{model}' not in pricing.json, using default pricing"
+            )
         try:
-            cost = (
-                (prompt / 1000) * self.cost_estimation["chat"][model]["promptPrice"]
-            ) + (
-                (completion / 1000)
-                * self.cost_estimation["chat"][model]["completionPrice"]
+            return (
+                (prompt / 1000) * pricing["promptPrice"]
+                + (completion / 1000) * pricing["completionPrice"]
             )
         except KeyError:
             raise UndefinedPriceError
         except Exception:
-            cost = 0
-        return cost
+            return 0
 
     def capture_messages(self):
         return self.valves.capture_message_content
@@ -171,6 +177,9 @@ class Pipeline:
 
     async def on_valves_updated(self):
         self.log(f"on_valves_updated:{__name__}")
+        self.cost_estimation = fetch_json_from_url_stdlib(
+            self.valves.pricing_information
+        )
         self.setup()
 
     async def inlet(self, body: dict, user: Optional[dict] = None) -> dict:


### PR DESCRIPTION
## Summary
- Add `chat["default"]` fallback in `get_chat_model_cost` so models missing from `pricing.json` get an estimated cost instead of being silently skipped (still logged as "using default pricing" so gaps stay visible).
- Re-fetch the pricing JSON in `on_valves_updated` so changing the `pricing_information` valve at runtime takes effect (previously only `__init__` fetched it).
- Seed `chat.default` at `0.0001` / `0.0001` (matches the most common open-model entries) — tune in the JSON without redeploying.
- Add `llama3.2` to `pricing.json`.

## Test plan
- [ ] Send a chat request with a model NOT in `pricing.json` and verify a non-zero `gen_ai.usage.cost` is recorded along with a `"using default pricing"` debug log line.
- [ ] Update the `pricing_information` valve to a new URL in the Open WebUI admin UI, send a request, and verify the new prices are applied without restarting the pipeline pod.
- [ ] Send a chat request with `llama3.2` and verify the cost matches the new entry.