### PR TITLE
feat: add vgpu utilization metrics

### DIFF
--- a/knowledge/METRIC_BINDINGS_GUIDE.md
+++ b/knowledge/METRIC_BINDINGS_GUIDE.md
@@ -8,7 +8,8 @@ Metric binding IDs are negative integers organized by category:
 - **-520 to -527**: vLLM per-model (genai-model) metrics
 - **-540 to -568**: Individual product metrics (vLLM, Ollama, etc.)
 - **-569 to -583**: Application-scoped GenAI metrics
-- **-584 to -605**: Common GPU/infrastructure metrics
+- **-584 to -608**: Common GPU/infrastructure metrics (including vGPU at -606 to -608)
+- **-615 to -617**: Pod-level vGPU metrics
 - **-700 to -705**: GenAI global metrics (genai-metrics.sty)
 - **-2000 to -2004**: Milvus/OpenSearch/Elasticsearch metrics
 

--- a/stackpack/suse-ai/provisioning/templates/metric-bindings/common-metrics.sty
+++ b/stackpack/suse-ai/provisioning/templates/metric-bindings/common-metrics.sty
@@ -233,3 +233,66 @@
       componentSummary:
         weight: 3
     _type: MetricBinding
+
+  - id: -615
+    name: vGPU Utilization
+    description: GPU utilization filtered to vGPU instances.
+    queries:
+      - expression: DCGM_FI_DEV_GPU_UTIL{ k8s_node_name="${tags.node-name}", pod_name="${name}", gpu_instance_id=~".+" }
+        alias: GPU ${gpu}
+        primary: true
+    scope: type IN ("pod")
+    identifier: urn:stackpack:suse-ai:shared:metric-binding:common:pod-vgpu-utilization
+    unit: percent
+    chartType: line
+    priority: high
+    enabled: true
+    layout:
+      metricPerspective:
+        tab: GPU
+        section: Utilization
+      componentSummary:
+        weight: 2
+    _type: MetricBinding
+
+  - id: -616
+    name: vGPU Per-Process Utilization
+    description: GPU utilization grouped by container process on vGPU instances.
+    queries:
+      - expression: sum by (exported_container) (DCGM_FI_DEV_GPU_UTIL{ k8s_node_name="${tags.node-name}", pod_name="${name}", gpu_instance_id=~".+" })
+        alias: ${exported_container}
+        primary: true
+    scope: type IN ("pod")
+    identifier: urn:stackpack:suse-ai:shared:metric-binding:common:pod-vgpu-per-process-utilization
+    unit: percent
+    chartType: line
+    priority: high
+    enabled: true
+    layout:
+      metricPerspective:
+        tab: GPU
+        section: Utilization
+      componentSummary:
+        weight: 2
+    _type: MetricBinding
+
+  - id: -617
+    name: vGPU Memory Usage
+    description: Framebuffer memory used by vGPU instances.
+    queries:
+      - expression: DCGM_FI_DEV_FB_USED{ k8s_node_name="${tags.node-name}", pod_name="${name}", gpu_instance_id=~".+" }
+        alias: GPU ${gpu}
+        primary: true
+    scope: type IN ("pod")
+    identifier: urn:stackpack:suse-ai:shared:metric-binding:common:pod-vgpu-memory-usage
+    unit: bytes
+    chartType: line
+    priority: high
+    enabled: true
+    layout:
+      metricPerspective:
+        tab: GPU
+        section: Utilization
+      componentSummary:
+        weight: 2
+    _type: MetricBinding

--- a/stackpack/suse-ai/provisioning/templates/metric-bindings/gpu-metrics.sty
+++ b/stackpack/suse-ai/provisioning/templates/metric-bindings/gpu-metrics.sty
@@ -233,3 +233,66 @@
       componentSummary:
         weight: 3
     _type: MetricBinding
+
+  - id: -606
+    name: vGPU Utilization
+    description: GPU utilization filtered to vGPU instances.
+    queries:
+      - expression: DCGM_FI_DEV_GPU_UTIL{ k8s_node_name="${name}", gpu_instance_id=~".+" }
+        alias: GPU ${gpu}
+        primary: true
+    scope: (label IN ("nvidia.com/gpu.present:true") AND type IN ("node"))
+    identifier: urn:stackpack:suse-ai:shared:metric-binding:common:node-vgpu-utilization
+    unit: percent
+    chartType: line
+    priority: high
+    enabled: true
+    layout:
+      metricPerspective:
+        tab: GPU
+        section: Utilization
+      componentSummary:
+        weight: 2
+    _type: MetricBinding
+
+  - id: -607
+    name: vGPU Per-Process Utilization
+    description: GPU utilization grouped by container process on vGPU instances.
+    queries:
+      - expression: sum by (exported_container) (DCGM_FI_DEV_GPU_UTIL{ k8s_node_name="${name}", gpu_instance_id=~".+" })
+        alias: ${exported_container}
+        primary: true
+    scope: (label IN ("nvidia.com/gpu.present:true") AND type IN ("node"))
+    identifier: urn:stackpack:suse-ai:shared:metric-binding:common:node-vgpu-per-process-utilization
+    unit: percent
+    chartType: line
+    priority: high
+    enabled: true
+    layout:
+      metricPerspective:
+        tab: GPU
+        section: Utilization
+      componentSummary:
+        weight: 2
+    _type: MetricBinding
+
+  - id: -608
+    name: vGPU Memory Usage
+    description: Framebuffer memory used by vGPU instances.
+    queries:
+      - expression: DCGM_FI_DEV_FB_USED{ k8s_node_name="${name}", gpu_instance_id=~".+" }
+        alias: GPU ${gpu}
+        primary: true
+    scope: (label IN ("nvidia.com/gpu.present:true") AND type IN ("node"))
+    identifier: urn:stackpack:suse-ai:shared:metric-binding:common:node-vgpu-memory-usage
+    unit: bytes
+    chartType: line
+    priority: high
+    enabled: true
+    layout:
+      metricPerspective:
+        tab: GPU
+        section: Utilization
+      componentSummary:
+        weight: 2
+    _type: MetricBinding


### PR DESCRIPTION
Adds vGPU  metrics such as vGPU utilization, vGPU utilization per process and vgpu memory usage.

For SUSE AI Stack, this feature is directly dependent on the changes added to the stack here: [PR 81](https://github.com/SUSE/suse-ai-stack/pull/81)

Ticket: [SUSEAI-519](https://jira.suse.com/browse/SUSEAI-519)