### PR TITLE
fix: correct GPU metric unit labels (kwatt -> watt/celsius)

### DIFF
--- a/stackpack/suse-ai/provisioning/templates/metric-bindings/common-metrics.sty
+++ b/stackpack/suse-ai/provisioning/templates/metric-bindings/common-metrics.sty
@@ -30,7 +30,7 @@
         primary: true
     scope: type IN ("pod")
     identifier: urn:stackpack:suse-ai:shared:metric-binding:common:pod-gpu-power-total
-    unit: kwatt
+    unit: watt
     chartType: line
     tags:
       experimental_chartType: Gauge
@@ -53,7 +53,7 @@
         primary: true
     scope: type IN ("pod")
     identifier: urn:stackpack:suse-ai:shared:metric-binding:common:pod-gpu-temperature
-    unit: kwatt
+    unit: celsius
     chartType: line
     priority: high
     enabled: true
@@ -73,7 +73,7 @@
         primary: true
     scope: type IN ("pod")
     identifier: urn:stackpack:suse-ai:shared:metric-binding:common:pod-gpu-power-usage
-    unit: kwatt
+    unit: watt
     chartType: line
     priority: high
     enabled: true

--- a/stackpack/suse-ai/provisioning/templates/metric-bindings/gpu-metrics.sty
+++ b/stackpack/suse-ai/provisioning/templates/metric-bindings/gpu-metrics.sty
@@ -30,7 +30,7 @@
         primary: true
     scope: (label IN ("nvidia.com/gpu.present:true") AND type IN ("node"))
     identifier: urn:stackpack:suse-ai:shared:metric-binding:common:node-gpu-power-total
-    unit: kwatt
+    unit: watt
     chartType: line
     tags:
       experimental_chartType: Gauge
@@ -53,7 +53,7 @@
         primary: true
     scope: (label IN ("nvidia.com/gpu.present:true") AND type IN ("node"))
     identifier: urn:stackpack:suse-ai:shared:metric-binding:common:node-gpu-temperature
-    unit: kwatt
+    unit: celsius
     chartType: line
     priority: high
     enabled: true
@@ -73,7 +73,7 @@
         primary: true
     scope: (label IN ("nvidia.com/gpu.present:true") AND type IN ("node"))
     identifier: urn:stackpack:suse-ai:shared:metric-binding:common:node-gpu-power-usage
-    unit: kwatt
+    unit: watt
     chartType: line
     priority: high
     enabled: true


### PR DESCRIPTION
DCGM_FI_DEV_POWER_USAGE reports watts and DCGM_FI_DEV_GPU_TEMP reports celsius, but several bindings were tagged unit: kwatt, inflating power readings 1000x and mislabeling temperature charts.

Fixes #52