### PR TITLE
feat: adapt to OTel db.system rename and add GenAI error-rate binding

### DIFF
--- a/integrations/otel-collector/otel-values.yaml
+++ b/integrations/otel-collector/otel-values.yaml
@@ -183,6 +183,17 @@ config:
       - key: service.instance.id
         from_attribute: k8s.pod.uid
         action: insert
+    # Backfill the legacy db.system attribute from the stable db.system.name
+    # (OTel database semconv rename). The topology exporter and the upstream
+    # OpenTelemetry StackPack discover database relations (app -> vectordb) from
+    # db.system on CLIENT spans; without this, instrumentation emitting only
+    # db.system.name would lose those relations. db.system.name is kept intact.
+    transform/db-semconv-compat:
+      error_mode: ignore
+      trace_statements:
+        - context: span
+          statements:
+            - set(attributes["db.system"], attributes["db.system.name"]) where attributes["db.system"] == nil and attributes["db.system.name"] != nil
     # Infer inference engines from GenAI client metrics.
     # When Open WebUI sends metrics with gen_ai.provider.name (e.g., "ollama", "vllm"),
     # this pipeline creates separate topology elements for each provider.
@@ -295,7 +306,7 @@ config:
     pipelines:
       traces:
         receivers: [otlp, jaeger]
-        processors: [filter/dropMissingK8sAttributes, memory_limiter, resource]
+        processors: [filter/dropMissingK8sAttributes, memory_limiter, resource, transform/db-semconv-compat]
         exporters: [routing/traces]
       traces/spanmetrics:
         receivers: [routing/traces]

--- a/stackpack/suse-ai/provisioning/templates/metric-bindings/genai-metrics.sty
+++ b/stackpack/suse-ai/provisioning/templates/metric-bindings/genai-metrics.sty
@@ -78,6 +78,27 @@
         weight: 3
 
   - _type: MetricBinding
+    id: -2005
+    name: Request Error Rate
+    identifier: urn:stackpack:suse-ai:shared:metric-binding:request-error-rate
+    unit: percentunit
+    chartType: line
+    priority: high
+    enabled: true
+    scope: label IN ("suse.ai.managed:true") AND type IN ("ui.open-webui", "inference-engine.vllm", "inference-engine.ollama", "model-proxy.litellm", "application", "agent")
+    queries:
+      # error.type is only attached to gen_ai.client.operation.duration on failure,
+      # so error_type!="" isolates failed requests. Ratio of failed to total requests.
+      - expression: sum by (gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_count{suse_ai_component_name="${name}", error_type!=""}[${__rate_interval}])) / sum by (gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_count{suse_ai_component_name="${name}"}[${__rate_interval}]))
+        alias: "${gen_ai_request_model}"
+    layout:
+      metricPerspective:
+        tab: LLM
+        section: Performance
+      componentSummary:
+        weight: 3
+
+  - _type: MetricBinding
     id: -2004
     name: Token Usage by Type
     identifier: urn:stackpack:suse-ai:shared:metric-binding:token-usage-by-type


### PR DESCRIPTION
## Summary

Adapts the observability extension to two demo-app instrumentation changes:

- **`db.system` → `db.system.name` (breaking fix).** Database dependency relations (app → qdrant/milvus/opensearch, remapped `database`→`queries`/`uses`) are discovered from the `db.system` span attribute by the topology exporter (`traces/topology` pipeline) and the upstream OpenTelemetry StackPack. Instrumentation that migrated to the stable `db.system.name` would silently drop those edges. A new `transform/db-semconv-compat` OTTL processor in the base `traces` pipeline backfills `db.system` from `db.system.name` when the legacy key is absent (`db.system.name` is left intact). This runs before `routing/traces`, so all downstream trace pipelines benefit.

- **`error.type` on `gen_ai.client.operation.duration` (new capability).** Adds a "Request Error Rate" GenAI metric binding (id `-2005`) that uses the new `error.type` label to compute the per-model ratio of failed to total requests. Existing `sum(...)` queries already absorb the new label, so nothing else changes.

## Not in scope (verified no impact)

- `db.operation.batch_size` → `db.operation.batch.size`: no references in the extension (vectordb metrics are Prometheus-scraped, not span-derived).
- `gen_ai.input.messages` / `gen_ai.output.messages`: the extension already uses these names.
- Resource attrs (`service.version`, `deployment.environment.name`, `service.instance.id`) and `span.record_exception`: additive, non-breaking.

## Notes

- Base branch is `main` (not `trunk`) because `origin/trunk` is 167 commits behind and does not contain `integrations/` or `stackpack/`.

## Testing

- `otel-values.yaml` validated as well-formed YAML.
- New metric-binding id `-2005` checked for collisions across all `.sty` files.