### PR TITLE
chore: version v2.1.0

### DIFF
--- a/stackpack/suse-ai/resources/RELEASE.md
+++ b/stackpack/suse-ai/resources/RELEASE.md
@@ -1,5 +1,10 @@
 # SUSE AI Observability StackPack
 
+## Version 2.1.0
+
+- Fixed product-to-product topology not appearing in the UI: the "SUSE AI Topology" sync now consumes the topology exporter's fixed stream topic.
+- Added multi-cluster support: product components now carry a `k8s.cluster.name` label (sourced from `K8S_CLUSTER_NAME`) as metadata, so the same product aggregates across clusters.
+
 ## Version 0.1.241
 
 - Consolidated vLLM latency charts into multi-query bindings (P99/P95/P90/P50/Avg in a single chart).

--- a/stackpack/suse-ai/stackpack.conf
+++ b/stackpack/suse-ai/stackpack.conf
@@ -1,5 +1,5 @@
 name = "suse-ai"
-version = "2.0.0"
+version = "2.1.0"
 displayName = "SUSE AI Observability"
 categories = [ "AI", "GenAI", "Monitoring" ]
 releaseStatus = AVAILABLE


### PR DESCRIPTION
Bumps the stackpack version to `2.1.0` in preparation for cutting the `v2.1.0` release.

## Changes
- `stackpack.conf`: `version` `2.0.0` → `2.1.0`
- `RELEASE.md`: new `## Version 2.1.0` entry covering:
  - Fix for product-to-product topology not appearing in the UI (topology sync now consumes the exporter's fixed stream topic).
  - Multi-cluster support via a `k8s.cluster.name` label on product components.