### PR TITLE
fix(otel): tag inferred application components with k8s.namespace.name

### DIFF
--- a/integrations/otel-collector/otel-values.yaml
+++ b/integrations/otel-collector/otel-values.yaml
@@ -243,6 +243,8 @@ config:
             - set(attributes["suse.ai.managed"], "true")
             - set(attributes["suse.ai.component.type"], "application")
             - set(attributes["suse.ai.component.name"], attributes["service.name"])
+            - set(attributes["k8s.namespace.name"], attributes["service.namespace"]) where attributes["service.namespace"] != nil
+            - set(attributes["k8s.namespace.name"], "${env:SUSE_AI_NAMESPACE}") where attributes["service.namespace"] == nil
     # Create provider -> model relations from GenAI trace spans.
     # Transforms spans so service.name = provider and peer.service = model,
     # which StackState interprets as a service dependency.


### PR DESCRIPTION
## Problem

In the SUSE AI Observability extension, the **Namespace** column in the *AI Applications* component-overview table is blank for **application**-type components, while every other component type (inference engines, models, vector DBs, UI) shows a namespace.

## Root cause

The Namespace column reads the component tag `k8s.namespace.name`:

```yaml
# view-types/ai-applications.sty
- title: Namespace
  path: ["tags", "k8s.namespace.name"]
  _type: ViewTypeTableColText
```

Application components never carry that tag. The three sibling inference transforms in `integrations/otel-collector/otel-values.yaml` were inconsistent:

- `transform/infer-providers` → sets `k8s.namespace.name` ✅
- `transform/infer-models` → sets `k8s.namespace.name` ✅
- `transform/infer-applications` → only set `suse.ai.*`, **missing** `k8s.namespace.name` ❌

The `metrics/infer-applications` pipeline also does not run the `k8sattributes` processor (the `kubernetesAttributes` preset only injects it into the default `traces`/`metrics`/`logs` pipelines), so there was no other source for the tag. Application resources therefore reached SUSE Observability without `k8s.namespace.name`, leaving the column empty.

Confirmed against a live cluster via `sts`: `agent-service`, `rag-service`, `llm-service` (type `application`) had no `k8s.namespace.name` tag, while all other managed components did.

## Fix

Add to `transform/infer-applications` the same two statements its siblings already use:

```yaml
- set(attributes["k8s.namespace.name"], attributes["service.namespace"]) where attributes["service.namespace"] != nil
- set(attributes["k8s.namespace.name"], "${env:SUSE_AI_NAMESPACE}") where attributes["service.namespace"] == nil
```

## Note

Like the other inferred components, this yields the `service.namespace` value (or the `SUSE_AI_NAMESPACE` fallback), not the real pod namespace, since k8s-attributes enrichment is not part of this pipeline. Surfacing the true pod namespace would be a separate, larger change.